### PR TITLE
Use tracked properties and retire DeclarationsChanged

### DIFF
--- a/xalia/UiDom/UiDomElement.cs
+++ b/xalia/UiDom/UiDomElement.cs
@@ -520,7 +520,7 @@ namespace Xalia.UiDom
             }
         }
 
-        protected virtual void DeclarationsChanged(Dictionary<string, (GudlDeclaration, UiDomValue)> all_declarations,
+        private void DeclarationsChanged(Dictionary<string, (GudlDeclaration, UiDomValue)> all_declarations,
             HashSet<(UiDomElement, GudlExpression)> dependencies)
         {
             HashSet<GudlExpression> changed = new HashSet<GudlExpression>();

--- a/xalia/Uia/UiaConnection.cs
+++ b/xalia/Uia/UiaConnection.cs
@@ -30,6 +30,7 @@ namespace Xalia.Uia
         internal Dictionary<string, PropertyId> names_to_property = new Dictionary<string, PropertyId>();
         internal Dictionary<PropertyId, string> properties_to_name = new Dictionary<PropertyId, string>();
         internal Dictionary<uint, List<PropertyId>> msaa_event_properties = new Dictionary<uint, List<PropertyId>>();
+        private string[] property_poll_names;
 
         bool polling_focus;
         CancellationTokenSource focus_poll_token;
@@ -474,6 +475,23 @@ namespace Xalia.Uia
                     msaa_event_properties[msaa_change_event] = propids;
                 }
                 propids.Add(propid);
+            }
+        }
+
+        internal string[] PropertyPollNames
+        {
+            get
+            {
+                if (property_poll_names is null)
+                {
+                    List<string> result = new List<string>();
+                    foreach (var propname in names_to_property.Keys)
+                    {
+                        result.Add("poll_" + propname);
+                    }
+                    property_poll_names = result.ToArray();
+                }
+                return property_poll_names;
             }
         }
 


### PR DESCRIPTION
The `DeclarationsChanged` method is inconvenient to use because it doesn't say which declarations changed. This means we have to check every declaration we care about for changes every time any declarations change. It also would prevent an update to gudl allowing "late evaluations" (for this update, we'd need to remove RaiseElementDeclarationsChangedEvent as well).

Doing this cleanup now so supporting `use_msaa_element` in #1 can be done more cleanly and we don't need the unrelated micro-optimization.