### PR TITLE
Initial implementation of element providers

### DIFF
--- a/xalia/AtSpi/AtSpiConnection.cs
+++ b/xalia/AtSpi/AtSpiConnection.cs
@@ -13,8 +13,6 @@ namespace Xalia.AtSpi
     {
         internal Connection connection;
 
-        public override string DebugId => "AtSpiConnection";
-
         IRegistry registry;
 
         private AtSpiConnection(Connection connection, GudlStatement[] rules, IUiDomApplication application) : base(rules, application)

--- a/xalia/AtSpi/AtSpiElement.cs
+++ b/xalia/AtSpi/AtSpiElement.cs
@@ -15,8 +15,6 @@ namespace Xalia.AtSpi
         internal readonly AtSpiConnection Connection;
         internal readonly string Service;
         internal readonly string Path;
-        public override string DebugId => string.Format("{0}:{1}", Service, Path);
-
         private bool watching_children;
         private bool children_known;
         private bool polling_children;
@@ -260,7 +258,7 @@ namespace Xalia.AtSpi
             }
         }
 
-        internal AtSpiElement(AtSpiConnection connection, string service, string path) : base(connection)
+        internal AtSpiElement(AtSpiConnection connection, string service, string path) : base($"{service}:{path}", connection)
         {
             Path = path;
             Service = service;

--- a/xalia/AtSpi2/AccessibleProvider.cs
+++ b/xalia/AtSpi2/AccessibleProvider.cs
@@ -1,0 +1,71 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xalia.Gudl;
+using Xalia.UiDom;
+
+namespace Xalia.AtSpi2
+{
+    internal class AccessibleProvider : IUiDomProvider
+    {
+        public AccessibleProvider(AtSpiConnection connection, string peer, string path)
+        {
+            Connection = connection;
+            Peer = peer;
+            Path = path;
+        }
+
+        public AtSpiConnection Connection { get; }
+        public string Peer { get; }
+        public string Path { get; }
+
+        public void DumpProperties(UiDomElement element)
+        {
+        }
+
+        public UiDomValue EvaluateIdentifier(UiDomElement element, string identifier, HashSet<(UiDomElement, GudlExpression)> depends_on)
+        {
+            switch (identifier)
+            {
+                case "is_uia_element":
+                    return UiDomBoolean.False;
+                case "is_spi_element":
+                case "is_atspi_element":
+                case "is_at_spi_element":
+                    return UiDomBoolean.True;
+                case "spi_peer":
+                    return new UiDomString(Peer);
+                case "spi_path":
+                    return new UiDomString(Path);
+            }
+            return UiDomUndefined.Instance;
+        }
+
+        public UiDomValue EvaluateIdentifierLate(UiDomElement element, string identifier, HashSet<(UiDomElement, GudlExpression)> depends_on)
+        {
+            return UiDomUndefined.Instance;
+        }
+
+        public Task<(bool, int, int)> GetClickablePointAsync(UiDomElement element)
+        {
+            return Task.FromResult((false, 0, 0));
+        }
+
+        public void NotifyElementRemoved(UiDomElement element)
+        {
+        }
+
+        public void TrackedPropertyChanged(UiDomElement element, string name, UiDomValue new_value)
+        {
+        }
+
+        public bool UnwatchProperty(UiDomElement element, GudlExpression expression)
+        {
+            return false;
+        }
+
+        public bool WatchProperty(UiDomElement element, GudlExpression expression)
+        {
+            return false;
+        }
+    }
+}

--- a/xalia/AtSpi2/AccessibleProvider.cs
+++ b/xalia/AtSpi2/AccessibleProvider.cs
@@ -1,22 +1,32 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using Tmds.DBus.Protocol;
 using Xalia.Gudl;
 using Xalia.UiDom;
+using static Xalia.AtSpi2.DBusUtils;
 
 namespace Xalia.AtSpi2
 {
     internal class AccessibleProvider : IUiDomProvider
     {
-        public AccessibleProvider(AtSpiConnection connection, string peer, string path)
+        public AccessibleProvider(UiDomElement element, AtSpiConnection connection, string peer, string path)
         {
+            Element = element;
             Connection = connection;
             Peer = peer;
             Path = path;
         }
 
+        public UiDomElement Element { get; private set; }
         public AtSpiConnection Connection { get; }
         public string Peer { get; }
         public string Path { get; }
+
+        private static string[] _trackedProperties = new string[] { "recurse_method" };
+
+        private bool watching_children;
+        private bool children_known;
 
         public void DumpProperties(UiDomElement element)
         {
@@ -42,6 +52,13 @@ namespace Xalia.AtSpi2
 
         public UiDomValue EvaluateIdentifierLate(UiDomElement element, string identifier, HashSet<(UiDomElement, GudlExpression)> depends_on)
         {
+            switch (identifier)
+            {
+                case "recurse_method":
+                    if (element.EvaluateIdentifier("recurse", element.Root, depends_on).ToBool())
+                        return new UiDomString("spi_auto");
+                    break;
+            }
             return UiDomUndefined.Instance;
         }
 
@@ -50,12 +67,210 @@ namespace Xalia.AtSpi2
             return Task.FromResult((false, 0, 0));
         }
 
+        public string[] GetTrackedProperties()
+        {
+            return _trackedProperties;
+        }
+
         public void NotifyElementRemoved(UiDomElement element)
         {
+            watching_children = false;
+            children_known = false;
+            Element = null;
+        }
+
+        private async Task<List<(string, string)>> GetChildList()
+        {
+            try
+            {
+                var children = await CallMethod(Connection.Connection, Peer, Path,
+                    IFACE_ACCESSIBLE, "GetChildren", ReadMessageElementList);
+
+                if (children.Count == 0)
+                {
+                    var child_count = (int)await GetProperty(Connection.Connection, Peer, Path,
+                        IFACE_ACCESSIBLE, "ChildCount");
+                    if (child_count != 0)
+                    {
+                        // This happens for AtkSocket/AtkPlug
+                        // https://gitlab.gnome.org/GNOME/at-spi2-core/-/issues/98
+
+                        children = new List<(string, string)>(child_count);
+
+                        for (int i = 0; i < child_count; i++)
+                        {
+                            children.Add(await CallMethod(Connection.Connection, Peer, Path,
+                                IFACE_ACCESSIBLE, "GetChildAtIndex", i, ReadMessageElement));
+                        }
+                    }
+                }
+
+                return children;
+            }
+            catch (DBusException e)
+            {
+                if (!AtSpiElement.IsExpectedException(e))
+                    throw;
+                return new List<(string, string)>();
+            }
+            catch (InvalidCastException)
+            {
+                return new List<(string, string)>();
+            }
+        }
+
+        private async Task PollChildrenTask()
+        {
+            if (!watching_children)
+                return;
+
+            await Connection.RegisterEvent("object:children-changed");
+
+            List<(string, string)> children = await GetChildList();
+
+            // Ignore any duplicate children
+            HashSet<(string, string)> seen_children = new HashSet<(string, string)>();
+            int i = 0;
+            while (i < children.Count)
+            {
+                if (!seen_children.Add(children[i]))
+                {
+                    children.RemoveAt(i);
+                    continue;
+                }
+                i++;
+            }
+
+            // First remove any existing children that are missing or out of order
+            i = 0;
+            foreach (var new_child in children)
+            {
+                if (!Element.Children.Exists((UiDomElement element) => ElementMatches(element, new_child)))
+                    continue;
+                while (!ElementMatches(Element.Children[i], new_child))
+                {
+                    Element.RemoveChild(i);
+                }
+                i++;
+            }
+
+            // Remove any remaining missing children
+            while (i < Element.Children.Count && Element.Children[i] is AtSpiElement)
+                Element.RemoveChild(i);
+
+            // Add any new children
+            i = 0;
+            foreach (var new_child in children)
+            {
+                if (Element.Children.Count <= i || !ElementMatches(Element.Children[i], new_child))
+                {
+                    if (!(Connection.LookupElement(new_child) is null))
+                    {
+                        // Child element is a duplicate of another element somewhere in the tree.
+                        continue;
+                    }
+                    Element.AddChild(i, new AtSpiElement(Connection, new_child.Item1, new_child.Item2));
+                }
+                i += 1;
+            }
+
+            children_known = true;
+        }
+
+        private bool ElementMatches(UiDomElement element, (string, string) new_child)
+        {
+            return element is AtSpiElement e && e.Peer == new_child.Item1 && e.Path == new_child.Item2;
+        }
+
+        internal void WatchChildren()
+        {
+            if (watching_children)
+                return;
+            if (Element.MatchesDebugCondition())
+                Utils.DebugWriteLine($"WatchChildren for {Element}");
+            watching_children = true;
+            children_known = false;
+            Utils.RunTask(PollChildrenTask());
+        }
+
+        internal void UnwatchChildren()
+        {
+            if (!watching_children)
+                return;
+            if (Element.MatchesDebugCondition())
+                Utils.DebugWriteLine($"UnwatchChildren for {Element}");
+            watching_children = false;
+            for (int i=Element.Children.Count-1; i >= 0; i--)
+            {
+                if (Element.Children[i] is AtSpiElement)
+                    Element.RemoveChild(i);
+            }
+        }
+
+        internal void AtSpiChildrenChanged(AtSpiSignal signal)
+        {
+            if (!children_known)
+                return;
+            var index = signal.detail1;
+            var child = ((string, ObjectPath))signal.value;
+            var child_element = Connection.LookupElement(child);
+            switch (signal.detail)
+            {
+                case "add":
+                    {
+                        if (!(child_element is null))
+                        {
+                            Utils.DebugWriteLine($"WARNING: {child_element} added to {Element} but is already a child of {child_element.Parent}, ignoring.");
+                            return;
+                        }
+                        if (index > Element.Children.Count || index < 0)
+                        {
+                            Utils.DebugWriteLine($"WARNING: {child.Item1}:{child.Item2} added to {Element} at index {index}, but there are only {Element.Children.Count} known children");
+                            index = Element.Children.Count;
+                        }
+                        Element.AddChild(index, new AtSpiElement(Connection, child.Item1, child.Item2));
+                        break;
+                    }
+                case "remove":
+                    {
+                        if (child_element is null)
+                        {
+                            Utils.DebugWriteLine($"WARNING: {child.Item1}:{child.Item2} removed from {Element}, but the element is unknown");
+                            return;
+                        }
+                        if (child_element.Parent != Element)
+                        {
+                            Utils.DebugWriteLine($"WARNING: {child.Item1}:{child.Item2} removed from {Element}, but is a child of {child_element.Parent}");
+                            return;
+                        }
+                        if (index >= Element.Children.Count || index < 0 || Element.Children[index] != child_element)
+                        {
+                            var real_index = Element.Children.IndexOf(child_element);
+                            Utils.DebugWriteLine($"WARNING: {child.Item1}:{child.Item2} remove event has wrong index - got {index}, should be {real_index}");
+                            index = real_index;
+                        }
+                        Element.RemoveChild(index);
+                        break;
+                    }
+                default:
+                    Utils.DebugWriteLine($"WARNING: unknown detail on ChildrenChanged event: {signal.detail}");
+                    break;
+            }
         }
 
         public void TrackedPropertyChanged(UiDomElement element, string name, UiDomValue new_value)
         {
+            switch (name)
+            {
+                case "recurse_method":
+                    {
+                        if (new_value is UiDomString st && st.Value == "spi_auto")
+                            WatchChildren();
+                        else
+                            UnwatchChildren();
+                        break;
+                    }
+            }
         }
 
         public bool UnwatchProperty(UiDomElement element, GudlExpression expression)

--- a/xalia/AtSpi2/AtSpiConnection.cs
+++ b/xalia/AtSpi2/AtSpiConnection.cs
@@ -97,7 +97,14 @@ namespace Xalia.AtSpi2
             var element = LookupElement((signal.peer, signal.path));
             if (element is null)
                 return;
-            element.AtSpiBoundsChanged(signal);
+            foreach (var provider in element.Providers)
+            {
+                if (provider is AccessibleProvider acc)
+                {
+                    acc.AtSpiBoundsChanged(signal);
+                    break;
+                }
+            }
         }
 
         private void OnStateChanged(AtSpiSignal signal)

--- a/xalia/AtSpi2/AtSpiConnection.cs
+++ b/xalia/AtSpi2/AtSpiConnection.cs
@@ -137,7 +137,14 @@ namespace Xalia.AtSpi2
             var element = LookupElement((signal.peer, signal.path));
             if (element is null)
                 return;
-            element.AtSpiPropertyChange(signal.detail, signal.value);
+            foreach (var provider in element.Providers)
+            {
+                if (provider is AccessibleProvider acc)
+                {
+                    acc.AtSpiPropertyChange(signal.detail, signal.value);
+                    break;
+                }
+            }
         }
 
         internal void NotifyElementCreated(AtSpiElement element)

--- a/xalia/AtSpi2/AtSpiConnection.cs
+++ b/xalia/AtSpi2/AtSpiConnection.cs
@@ -122,7 +122,14 @@ namespace Xalia.AtSpi2
             var element = LookupElement((signal.peer, signal.path));
             if (element is null)
                 return;
-            element.AtSpiChildrenChanged(signal);
+            foreach (var provider in element.Providers)
+            {
+                if (provider is AccessibleProvider acc)
+                {
+                    acc.AtSpiChildrenChanged(signal);
+                    break;
+                }
+            }
         }
 
         private void OnPropertyChange(AtSpiSignal signal)

--- a/xalia/AtSpi2/AtSpiConnection.cs
+++ b/xalia/AtSpi2/AtSpiConnection.cs
@@ -105,7 +105,14 @@ namespace Xalia.AtSpi2
             var element = LookupElement((signal.peer, signal.path));
             if (element is null)
                 return;
-            element.AtSpiStateChanged(signal);
+            foreach (var provider in element.Providers)
+            {
+                if (provider is AccessibleProvider acc)
+                {
+                    acc.AtSpiStateChanged(signal);
+                    break;
+                }
+            }
         }
 
         public Task RegisterEvent(string name)

--- a/xalia/AtSpi2/AtSpiElement.cs
+++ b/xalia/AtSpi2/AtSpiElement.cs
@@ -13,7 +13,7 @@ namespace Xalia.AtSpi2
 {
     internal class AtSpiElement : UiDomElement
     {
-        public AtSpiElement(AtSpiConnection root, string peer, string path): base(root)
+        public AtSpiElement(AtSpiConnection root, string peer, string path): base($"{peer}:{path}", root)
         {
             Root = root;
             Peer = peer;
@@ -77,8 +77,6 @@ namespace Xalia.AtSpi2
         public new AtSpiConnection Root { get; }
         public string Peer { get; }
         public string Path { get; }
-
-        public override string DebugId => $"{Peer}:{Path}";
 
         public bool RoleKnown { get; private set; }
         public int Role { get; private set; }

--- a/xalia/AtSpi2/AtSpiElement.cs
+++ b/xalia/AtSpi2/AtSpiElement.cs
@@ -18,6 +18,7 @@ namespace Xalia.AtSpi2
             Root = root;
             Peer = peer;
             Path = path;
+            AddProvider(new AccessibleProvider(root, peer, path));
             RegisterTrackedProperties(tracked_properties);
         }
 
@@ -319,16 +320,6 @@ namespace Xalia.AtSpi2
 
             switch (id)
             {
-                case "is_uia_element":
-                    return UiDomBoolean.False;
-                case "is_spi_element":
-                case "is_atspi_element":
-                case "is_at_spi_element":
-                    return UiDomBoolean.True;
-                case "spi_peer":
-                    return new UiDomString(Peer);
-                case "spi_path":
-                    return new UiDomString(Path);
                 case "spi_role":
                     depends_on.Add((this, new IdentifierExpression("spi_role")));
                     if (RoleKnown)

--- a/xalia/AtSpi2/AtSpiState.cs
+++ b/xalia/AtSpi2/AtSpiState.cs
@@ -51,7 +51,7 @@ namespace Xalia.AtSpi2
 
         public static uint[] SetState(uint[] flags, string state, bool value)
         {
-            if (AtSpiElement.name_to_state.TryGetValue(state, out var state_num))
+            if (AccessibleProvider.name_to_state.TryGetValue(state, out var state_num))
             {
                 return SetState(flags, state_num, value);
             }
@@ -67,7 +67,7 @@ namespace Xalia.AtSpi2
 
         public static bool IsStateSet(uint[] flags, string state)
         {
-            if (AtSpiElement.name_to_state.TryGetValue(state, out var state_num))
+            if (AccessibleProvider.name_to_state.TryGetValue(state, out var state_num))
             {
                 return IsStateSet(flags, state_num);
             }
@@ -80,7 +80,7 @@ namespace Xalia.AtSpi2
 
         protected override UiDomValue EvaluateIdentifierCore(string id, UiDomRoot root, [In, Out] HashSet<(UiDomElement, GudlExpression)> depends_on)
         {
-            if (AtSpiElement.name_to_state.TryGetValue(id, out var state))
+            if (AccessibleProvider.name_to_state.TryGetValue(id, out var state))
                 return UiDomBoolean.FromBool(IsStateSet(state));
             return base.EvaluateIdentifierCore(id, root, depends_on);
         }
@@ -99,14 +99,14 @@ namespace Xalia.AtSpi2
             }
             sb.Append(") ");
             first_token = true;
-            for (int i=0; i<AtSpiElement.state_names.Length; i++)
+            for (int i=0; i<AccessibleProvider.state_names.Length; i++)
             {
                 if (IsStateSet(i))
                 {
                     if (!first_token)
                         sb.Append('|');
                     first_token = false;
-                    sb.Append(AtSpiElement.state_names[i]);
+                    sb.Append(AccessibleProvider.state_names[i]);
                 }
             }
             sb.Append('>');

--- a/xalia/AtSpi2/AtSpiSupported.cs
+++ b/xalia/AtSpi2/AtSpiSupported.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using Xalia.Gudl;
+using Xalia.UiDom;
+
+namespace Xalia.AtSpi2
+{
+    internal class AtSpiSupported : UiDomValue
+    {
+        public AtSpiSupported(string[] interfaces)
+        {
+            Interfaces = interfaces;
+        }
+
+        public string[] Interfaces { get; }
+
+        public override string ToString()
+        {
+            var result = new StringBuilder();
+            result.Append($"spi_supported[");
+            bool delimiter = false;
+            foreach (string iface in Interfaces)
+            {
+                if (delimiter)
+                    result.Append("|");
+                String name;
+                if (iface.StartsWith("org.a11y.atspi."))
+                    name = ToSnakeCase(iface.Substring(15));
+                else
+                    name = iface;
+                result.Append(name);
+                delimiter = true;
+            }
+            result.Append("]");
+            return result.ToString();
+        }
+
+        static string ToCamelCase(string input)
+        {
+            var sb = new StringBuilder();
+
+            bool capitalize = true;
+
+            foreach (char c in input)
+            {
+                if (c == '_')
+                {
+                    capitalize = true;
+                    continue;
+                }
+
+                if (capitalize)
+                {
+                    sb.Append(char.ToUpper(c));
+                    capitalize = false;
+                    continue;
+                }
+
+                sb.Append(c);
+            }
+
+            return sb.ToString();
+        }
+
+        static string ToSnakeCase(string input)
+        {
+            var sb = new StringBuilder();
+
+            bool at_start = true;
+
+            foreach (char c in input)
+            {
+                if (at_start)
+                {
+                    sb.Append(char.ToLower(c));
+                    at_start = false;
+                    continue;
+                }
+
+                if (char.IsUpper(c))
+                {
+                    sb.Append("_");
+                    sb.Append(char.ToLower(c));
+                    continue;
+                }
+
+                sb.Append(c);
+                at_start = false;
+            }
+
+            return sb.ToString();
+        }
+        protected override UiDomValue EvaluateIdentifierCore(string id, UiDomRoot root, [In, Out] HashSet<(UiDomElement, GudlExpression)> depends_on)
+        {
+            string iface_name;
+
+            if (id.Contains("."))
+            {
+                iface_name = id;
+            }
+            else
+            {
+                iface_name = "org.a11y.atspi." + ToCamelCase(id);
+            }
+
+            return UiDomBoolean.FromBool(Interfaces.Contains(iface_name));
+        }
+    }
+}

--- a/xalia/AtSpi2/ComponentProvider.cs
+++ b/xalia/AtSpi2/ComponentProvider.cs
@@ -1,0 +1,200 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tmds.DBus.Protocol;
+using Xalia.Gudl;
+using Xalia.UiDom;
+using static Xalia.AtSpi2.DBusUtils;
+
+namespace Xalia.AtSpi2
+{
+    internal class ComponentProvider : IUiDomProvider
+    {
+        public ComponentProvider(AccessibleProvider accessible)
+        {
+            Accessible = accessible;
+        }
+
+        public AccessibleProvider Accessible { get; }
+
+        public AtSpiConnection Connection => Accessible.Connection;
+        public string Peer => Accessible.Peer;
+        public string Path => Accessible.Path;
+        public UiDomElement Element => Accessible.Element;
+
+        // Sync with AccessibleProvider.other_interface_properties
+        private static readonly Dictionary<string, string> property_aliases = new Dictionary<string, string>
+        {
+            { "x", "spi_abs_x" },
+            { "y", "spi_abs_y" },
+            { "width", "spi_abs_width" },
+            { "height", "spi_abs_height" },
+            { "abs_x", "spi_abs_x" },
+            { "abs_y", "spi_abs_y" },
+            { "abs_width", "spi_abs_width" },
+            { "abs_height", "spi_abs_height" },
+        };
+
+        public bool AbsPosKnown { get; private set; }
+        public int AbsX { get; private set; }
+        public int AbsY { get; private set; }
+        public int AbsWidth { get; private set; }
+        public int AbsHeight { get; private set; }
+        private bool watching_abs_pos;
+        private int abs_pos_change_count;
+
+        public void DumpProperties(UiDomElement element)
+        {
+            if (AbsPosKnown)
+            {
+                Utils.DebugWriteLine($"  spi_abs_x: {AbsX}");
+                Utils.DebugWriteLine($"  spi_abs_y: {AbsY}");
+                Utils.DebugWriteLine($"  spi_abs_width: {AbsWidth}");
+                Utils.DebugWriteLine($"  spi_abs_height: {AbsHeight}");
+            }
+        }
+
+        public UiDomValue EvaluateIdentifier(UiDomElement element, string identifier, HashSet<(UiDomElement, GudlExpression)> depends_on)
+        {
+            switch (identifier)
+            {
+                case "spi_abs_x":
+                    depends_on.Add((element, new IdentifierExpression("spi_abs_pos")));
+                    if (AbsPosKnown)
+                        return new UiDomInt(AbsX);
+                    return UiDomUndefined.Instance;
+                case "spi_abs_y":
+                    depends_on.Add((element, new IdentifierExpression("spi_abs_pos")));
+                    if (AbsPosKnown)
+                        return new UiDomInt(AbsY);
+                    return UiDomUndefined.Instance;
+                case "spi_abs_width":
+                    depends_on.Add((element, new IdentifierExpression("spi_abs_pos")));
+                    if (AbsPosKnown)
+                        return new UiDomInt(AbsWidth);
+                    return UiDomUndefined.Instance;
+                case "spi_abs_height":
+                    depends_on.Add((element, new IdentifierExpression("spi_abs_pos")));
+                    if (AbsPosKnown)
+                        return new UiDomInt(AbsHeight);
+                    return UiDomUndefined.Instance;
+            }
+            return UiDomUndefined.Instance;
+        }
+
+        public UiDomValue EvaluateIdentifierLate(UiDomElement element, string identifier, HashSet<(UiDomElement, GudlExpression)> depends_on)
+        {
+            if (property_aliases.TryGetValue(identifier, out var aliased))
+            {
+                return element.EvaluateIdentifier(aliased, element.Root, depends_on);
+            }
+            return UiDomUndefined.Instance;
+        }
+
+        public Task<(bool, int, int)> GetClickablePointAsync(UiDomElement element)
+        {
+            return Task.FromResult((false, 0, 0));
+        }
+
+        public string[] GetTrackedProperties()
+        {
+            return null;
+        }
+
+        public void NotifyElementRemoved(UiDomElement element)
+        {
+            watching_abs_pos = false;
+            AbsPosKnown = false;
+        }
+
+        public void TrackedPropertyChanged(UiDomElement element, string name, UiDomValue new_value)
+        {
+        }
+
+        public bool UnwatchProperty(UiDomElement element, GudlExpression expression)
+        {
+            if (expression is IdentifierExpression id)
+            {
+                switch (id.Name)
+                {
+                    case "spi_abs_pos":
+                        element.EndPollProperty(expression);
+                        watching_abs_pos = false;
+                        AbsPosKnown = false;
+                        return true;
+                }
+            }
+            return false;
+        }
+
+        public bool WatchProperty(UiDomElement element, GudlExpression expression)
+        {
+            if (expression is IdentifierExpression id)
+            {
+                switch (id.Name)
+                {
+                    case "spi_abs_pos":
+                        if (!watching_abs_pos)
+                        {
+                            watching_abs_pos = true;
+                            element.PollProperty(expression, FetchAbsPos, 2000);
+                        }
+                        return true;
+                }
+            }
+            return false;
+        }
+
+        private Task FetchAbsPos()
+        {
+            return FetchAbsPos(false);
+        }
+
+        private async Task FetchAbsPos(bool from_event)
+        {
+            (int, int, int, int) result;
+            int old_change_count = abs_pos_change_count;
+            using (var poll = await Accessible.LimitPolling(AbsPosKnown && !from_event))
+            {
+                if (!watching_abs_pos)
+                    return;
+                if (old_change_count != abs_pos_change_count)
+                    return;
+                try
+                {
+                    await Connection.RegisterEvent("object:bounds-changed");
+
+                    result = await CallMethod(Connection.Connection, Peer, Path,
+                        IFACE_COMPONENT, "GetExtents", (uint)0, ReadMessageExtents);
+                }
+                catch (DBusException e)
+                {
+                    if (!AtSpiElement.IsExpectedException(e))
+                        throw;
+                    return;
+                }
+            }
+            if (old_change_count != abs_pos_change_count)
+                return;
+            if (watching_abs_pos && (!AbsPosKnown || result != (AbsX, AbsY, AbsWidth, AbsHeight)))
+            {
+                AbsPosKnown = true;
+                AbsX = result.Item1;
+                AbsY = result.Item2;
+                AbsWidth = result.Item3;
+                AbsHeight = result.Item4;
+                if (Element.MatchesDebugCondition())
+                    Utils.DebugWriteLine($"{Element}.spi_abs_(x,y,width,height): {result}");
+                Element.PropertyChanged("spi_abs_pos");
+            }
+        }
+
+        internal void AncestorBoundsChanged()
+        {
+            abs_pos_change_count++;
+            if (watching_abs_pos)
+            {
+                Utils.RunTask(FetchAbsPos(true));
+            }
+        }
+    }
+}

--- a/xalia/AtSpi2/DBusUtils.cs
+++ b/xalia/AtSpi2/DBusUtils.cs
@@ -180,6 +180,18 @@ namespace Xalia.AtSpi2
             return message.GetBodyReader().ReadString();
         }
 
+        public static string[] ReadMessageStringArray(Message message, object state)
+        {
+            var reader = message.GetBodyReader();
+            var result = new List<string>();
+            var array = reader.ReadArrayStart(DBusType.String);
+            while (reader.HasNext(array))
+            {
+                result.Add(reader.ReadString());
+            }
+            return result.ToArray();
+        }
+
         public static int ReadMessageInt32(Message message, object state)
         {
             return message.GetBodyReader().ReadInt32();

--- a/xalia/UiDom/IUiDomProvider.cs
+++ b/xalia/UiDom/IUiDomProvider.cs
@@ -24,5 +24,7 @@ namespace Xalia.UiDom
         void DumpProperties(UiDomElement element);
 
         Task<(bool, int, int)> GetClickablePointAsync(UiDomElement element);
+
+        string[] GetTrackedProperties();
     }
 }

--- a/xalia/UiDom/IUiDomProvider.cs
+++ b/xalia/UiDom/IUiDomProvider.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xalia.Gudl;
+
+namespace Xalia.UiDom
+{
+    public interface IUiDomProvider
+    {
+        void NotifyElementRemoved(UiDomElement element);
+
+        // returns True if handled
+        bool WatchProperty(UiDomElement element, GudlExpression expression);
+
+        bool UnwatchProperty(UiDomElement element, GudlExpression expression);
+
+        UiDomValue EvaluateIdentifier(UiDomElement element, string identifier,
+            HashSet<(UiDomElement, GudlExpression)> depends_on);
+
+        UiDomValue EvaluateIdentifierLate(UiDomElement element, string identifier,
+            HashSet<(UiDomElement, GudlExpression)> depends_on);
+
+        void TrackedPropertyChanged(UiDomElement element, string name, UiDomValue new_value);
+
+        void DumpProperties(UiDomElement element);
+
+        Task<(bool, int, int)> GetClickablePointAsync(UiDomElement element);
+    }
+}

--- a/xalia/UiDom/UiDomElement.cs
+++ b/xalia/UiDom/UiDomElement.cs
@@ -9,7 +9,7 @@ namespace Xalia.UiDom
 {
     public abstract class UiDomElement : UiDomValue
     {
-        public abstract string DebugId { get; }
+        public string DebugId { get; }
 
         public List<UiDomElement> Children { get; } = new List<UiDomElement> ();
 
@@ -82,8 +82,9 @@ namespace Xalia.UiDom
             }
         }
 
-        public UiDomElement(UiDomRoot root)
+        public UiDomElement(string debug_id, UiDomRoot root)
         {
+            DebugId = debug_id;
             Root = root;
         }
 
@@ -92,6 +93,7 @@ namespace Xalia.UiDom
             if (this is UiDomRoot root)
             {
                 Root = root;
+                DebugId = "root";
                 SetAlive(true);
             }
             else

--- a/xalia/UiDom/UiDomElement.cs
+++ b/xalia/UiDom/UiDomElement.cs
@@ -106,7 +106,7 @@ namespace Xalia.UiDom
                 throw new InvalidOperationException("UiDomObject constructor with no arguments can only be used by UiDomRoot");
         }
 
-        protected void AddChild(int index, UiDomElement child)
+        public void AddChild(int index, UiDomElement child)
         {
             if (MatchesDebugCondition())
                 Utils.DebugWriteLine($"Child {child} added to {this} at index {index}");
@@ -136,7 +136,7 @@ namespace Xalia.UiDom
             return UiDomUndefined.Instance;
         }
 
-        protected void RemoveChild(int index)
+        public void RemoveChild(int index)
         {
             var child = Children[index];
             if (MatchesDebugCondition() || child.MatchesDebugCondition())
@@ -907,6 +907,9 @@ namespace Xalia.UiDom
         public void AddProvider(IUiDomProvider provider, int index)
         {
             Providers.Insert(index, provider);
+            var tracked = provider.GetTrackedProperties();
+            if (!(tracked is null))
+                RegisterTrackedProperties(tracked);
             if (!_updatingRules)
             {
                 _updatingRules = true;

--- a/xalia/UiDom/UiDomRoot.cs
+++ b/xalia/UiDom/UiDomRoot.cs
@@ -25,7 +25,5 @@ namespace Xalia.UiDom
         {
             Application.ElementDied(element);
         }
-
-        public override string DebugId => "root";
     }
 }

--- a/xalia/Uia/UiaConnection.cs
+++ b/xalia/Uia/UiaConnection.cs
@@ -725,8 +725,6 @@ namespace Xalia.Uia
                 element.UpdateChildren();
         }
 
-        public override string DebugId => "UiaConnection";
-
         public AutomationBase Automation { get; private set; }
         public SynchronizationContext MainContext { get; }
         

--- a/xalia/Uia/UiaElement.cs
+++ b/xalia/Uia/UiaElement.cs
@@ -23,7 +23,7 @@ namespace Xalia.Uia
             "win32_use_element", "win32_use_trackbar", "win32_use_tabcontrol", "win32_use_listview",
         };
 
-        public UiaElement(UiaElementWrapper wrapper) : base(wrapper.Connection)
+        public UiaElement(UiaElementWrapper wrapper) : base(wrapper.UniqueId, wrapper.Connection)
         {
             ElementWrapper = wrapper;
             RegisterTrackedProperties(tracked_properties);
@@ -31,14 +31,6 @@ namespace Xalia.Uia
         }
 
         public UiaElementWrapper ElementWrapper { get; }
-
-        public override string DebugId
-        {
-            get
-            {
-                return ElementWrapper.UniqueId;
-            }
-        }
 
         public string ElementIdentifier
         {
@@ -471,7 +463,7 @@ namespace Xalia.Uia
                     UseElementPropertyChanged(new_value,
                         // have to do slow check because Win32Element has subclasses
                         (UiDomElement e) => { return e.GetType() == typeof(Win32Element); },
-                        () => { return new Win32Element(ElementWrapper.Hwnd, Root); });
+                        () => { return new Win32Element("Win32Element", ElementWrapper.Hwnd, Root); });
                     break;
                 case "win32_use_trackbar":
                     UseElementPropertyChanged(new_value,

--- a/xalia/Uia/Win32/Win32Element.cs
+++ b/xalia/Uia/Win32/Win32Element.cs
@@ -34,15 +34,13 @@ namespace Xalia.Uia.Win32
             }
         }
 
-        internal Win32Element(IntPtr hwnd, UiaConnection root) : base(root)
+        public Win32Element(string typename, IntPtr hwnd, UiaConnection root) : base($"{typename}-{hwnd}", root)
         {
             Hwnd = hwnd;
             Root = root;
-            _debugid = $"{GetType().Name}-{hwnd}";
         }
 
         public new UiaConnection Root { get; }
-        private readonly string _debugid;
         private static readonly Dictionary<string, string> property_aliases;
         private string ProcessName;
 
@@ -71,13 +69,11 @@ namespace Xalia.Uia.Win32
         public int WindowStyle { get; private set; }
         public bool WindowStyleKnown { get; private set; }
 
-        public override string DebugId => _debugid;
-
         public override bool Equals(object obj)
         {
             if (obj is Win32Element win32)
             {
-                return _debugid == win32._debugid;
+                return DebugId == win32.DebugId;
             }
             return false;
         }

--- a/xalia/Uia/Win32/Win32ListView.cs
+++ b/xalia/Uia/Win32/Win32ListView.cs
@@ -12,7 +12,7 @@ namespace Xalia.Uia.Win32
 {
     internal class Win32ListView : Win32Element
     {
-        public Win32ListView(IntPtr hwnd, UiaConnection root) : base(hwnd, root)
+        public Win32ListView(IntPtr hwnd, UiaConnection root) : base("Win32ListView", hwnd, root)
         {
         }
 
@@ -457,7 +457,7 @@ namespace Xalia.Uia.Win32
                 {
                     if (!(Header is null))
                         RemoveChild(Children.IndexOf(Header));
-                    Header = new Win32Element(HeaderHwnd, Root);
+                    Header = new Win32Element("Win32Element", HeaderHwnd, Root);
                     AddChild(Children.Count, Header);
                     PropertyChanged("win32_header", Header);
                 }

--- a/xalia/Uia/Win32/Win32ListViewItem.cs
+++ b/xalia/Uia/Win32/Win32ListViewItem.cs
@@ -24,7 +24,8 @@ namespace Xalia.Uia.Win32
 
         private Win32RemoteProcessMemory remote_process_memory;
 
-        public Win32ListViewItem(Win32ListView parent, int index) : base(parent.Root)
+        public Win32ListViewItem(Win32ListView parent, int index) : base($"Win32ListViewItem-{parent.Hwnd}-{index}", parent.Root)
+
         {
             Parent = parent;
             Hwnd = parent.Hwnd;
@@ -43,8 +44,6 @@ namespace Xalia.Uia.Win32
             }
             base.SetAlive(value);
         }
-
-        public override string DebugId => $"Win32ListViewItem-{Hwnd}-{Index}";
 
         public new Win32ListView Parent { get; }
         public IntPtr Hwnd { get; }

--- a/xalia/Uia/Win32/Win32TabControl.cs
+++ b/xalia/Uia/Win32/Win32TabControl.cs
@@ -11,7 +11,7 @@ namespace Xalia.Uia.Win32
 {
     internal class Win32TabControl : Win32Element
     {
-        public Win32TabControl(IntPtr hwnd, UiaConnection root) : base(hwnd, root)
+        public Win32TabControl(IntPtr hwnd, UiaConnection root) : base("Win32TabControl", hwnd, root)
         {
         }
 

--- a/xalia/Uia/Win32/Win32TabControlItem.cs
+++ b/xalia/Uia/Win32/Win32TabControlItem.cs
@@ -11,7 +11,7 @@ namespace Xalia.Uia.Win32
 {
     internal class Win32TabControlItem : UiDomElement
     {
-        public Win32TabControlItem(Win32TabControl parent, int index) : base(parent.Root)
+        public Win32TabControlItem(Win32TabControl parent, int index) : base($"Win32TabControlItem-{parent.Hwnd}-{index}", parent.Root)
         {
             Parent = parent;
             Hwnd = parent.Hwnd;
@@ -30,8 +30,6 @@ namespace Xalia.Uia.Win32
             }
             base.SetAlive(value);
         }
-
-        public override string DebugId => $"Win32TabControlItem-{Hwnd}-{Index}";
 
         private static readonly UiDomValue role = new UiDomEnum(new[] { "tab_item", "tabitem", "page_tab", "pagetab" });
 

--- a/xalia/Uia/Win32/Win32Trackbar.cs
+++ b/xalia/Uia/Win32/Win32Trackbar.cs
@@ -11,7 +11,7 @@ namespace Xalia.Uia.Win32
 {
     internal class Win32Trackbar : Win32Element
     {
-        public Win32Trackbar(IntPtr hwnd, UiaConnection root) : base(hwnd, root) { }
+        public Win32Trackbar(IntPtr hwnd, UiaConnection root) : base("Win32Trackbar", hwnd, root) { }
 
         static UiDomEnum role = new UiDomEnum(new string[] { "slider" });
         static Win32Trackbar()

--- a/xalia/Uia/Win32/Win32VirtualScrollbar.cs
+++ b/xalia/Uia/Win32/Win32VirtualScrollbar.cs
@@ -10,7 +10,8 @@ namespace Xalia.Uia.Win32
 {
     public class Win32VirtualScrollbar : UiDomElement
     {
-        public Win32VirtualScrollbar(Win32Element parent, bool vertical) : base(parent.Root)
+        public Win32VirtualScrollbar(Win32Element parent, bool vertical) :
+            base($"Win32VirtualScrollbar-{parent.Hwnd}-{(vertical ? 'V' : 'H')}", parent.Root)
         {
             Parent = parent;
             Vertical = vertical;
@@ -42,8 +43,6 @@ namespace Xalia.Uia.Win32
         public new Win32Element Parent { get; }
         public bool Vertical { get; }
         public IntPtr Hwnd { get; }
-
-        public override string DebugId => $"Win32VirtualScrollbar-{Hwnd}-{(Vertical ? 'V': 'H')}";
 
         protected override UiDomValue EvaluateIdentifierCore(string id, UiDomRoot root, [In, Out] HashSet<(UiDomElement, GudlExpression)> depends_on)
         {

--- a/xalia/xalia.csproj
+++ b/xalia/xalia.csproj
@@ -97,6 +97,8 @@
     <Compile Include="AtSpi2\AtSpiConnection.cs" />
     <Compile Include="AtSpi2\AtSpiElement.cs" />
     <Compile Include="AtSpi2\AtSpiState.cs" />
+    <Compile Include="AtSpi2\AtSpiSupported.cs" />
+    <Compile Include="AtSpi2\ComponentProvider.cs" />
     <Compile Include="AtSpi2\DBusUtils.cs" />
     <Compile Include="AtSpi\AtSpiActionList.cs" />
     <Compile Include="GlobalSuppressions.cs" />

--- a/xalia/xalia.csproj
+++ b/xalia/xalia.csproj
@@ -92,6 +92,7 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AtSpi2\AccessibleProvider.cs" />
     <Compile Include="AtSpi2\AtSpiActionList.cs" />
     <Compile Include="AtSpi2\AtSpiConnection.cs" />
     <Compile Include="AtSpi2\AtSpiElement.cs" />
@@ -111,6 +112,7 @@
     <Compile Include="Uia\Win32\Win32TabControlItem.cs" />
     <Compile Include="Uia\Win32\Win32Trackbar.cs" />
     <Compile Include="Uia\Win32\Win32VirtualScrollbar.cs" />
+    <Compile Include="UiDom\IUiDomProvider.cs" />
     <Compile Include="UiDom\UiDomAdjustScrollbars.cs" />
     <Compile Include="AtSpi\AtSpiAttributes.cs" />
     <Compile Include="AtSpi\AtSpiConnection.cs" />


### PR DESCRIPTION
This should eventually be much cleaner than the hodgepodge of subclasses and hooks we have now.

Obsoletes #1 because between this and the need to move away from relying on UIA so much, AtSpi.Uia might as well be rewritten at this point, and there's little reason to make substantial changes to it.