### PR TITLE
Win32: Use a dedicated background thread for each remote UI thread.

### DIFF
--- a/xalia/Interop/Win32.cs
+++ b/xalia/Interop/Win32.cs
@@ -993,13 +993,18 @@ namespace Xalia.Interop
             {
                 handle.DangerousAddRef(ref success);
 
+                if (!success || handle.IsClosed || handle.IsInvalid)
+                    // Avoids race condition when another thread may free the handle - treat that as signaled
+                    return 0;
+
                 raw_handle = handle.DangerousGetHandle();
 
                 return MsgWaitForMultipleObjects(1, &raw_handle, false, dwMilliseconds, dwWakeMask);
             }
             finally
             {
-                handle.DangerousRelease();
+                if (success)
+                    handle.DangerousRelease();
             }
         }
 

--- a/xalia/Win32/AccessibleProvider.cs
+++ b/xalia/Win32/AccessibleProvider.cs
@@ -33,6 +33,7 @@ namespace Xalia.Win32
         public UiDomElement Element { get; private set; }
         public Win32Connection Connection => RootHwnd.Connection;
         public int Tid => RootHwnd.Tid;
+        public CommandThread CommandThread => RootHwnd.CommandThread;
         public IAccessible IAccessible { get; private set; }
         public int ChildId { get; }
 
@@ -498,12 +499,12 @@ namespace Xalia.Win32
 
             try
             {
-                new_value = await Connection.CommandThread.OnBackgroundThread(() =>
+                new_value = await CommandThread.OnBackgroundThread(() =>
                 {
                     if (old_change_count != _defaultActionChangeCount)
                         return null;
                     return IAccessible.get_accDefaultAction(ChildId);
-                }, Tid+1);
+                }, CommandThreadPriority.Query);
             }
             catch (Exception e)
             {
@@ -532,12 +533,12 @@ namespace Xalia.Win32
 
             try
             {
-                new_state = await Connection.CommandThread.OnBackgroundThread(() =>
+                new_state = await CommandThread.OnBackgroundThread(() =>
                 {
                     if (old_change_count != _stateChangeCount)
                         return null;
                     return IAccessible.get_accState(ChildId) as int?;
-                }, polling ? Tid + 2 : Tid + 1);
+                }, polling ? CommandThreadPriority.Poll : CommandThreadPriority.Query);
             }
             catch (Exception e)
             {
@@ -585,7 +586,7 @@ namespace Xalia.Win32
 
             try
             {
-                new_location = await Connection.CommandThread.OnBackgroundThread(() =>
+                new_location = await CommandThread.OnBackgroundThread(() =>
                 {
                     if (old_change_count != _locationChangeCount)
                         return default;
@@ -596,7 +597,7 @@ namespace Xalia.Win32
                     result.right = x + width;
                     result.bottom = y + height;
                     return result;
-                }, Tid+1);
+                }, CommandThreadPriority.Query);
             }
             catch (Exception e)
             {
@@ -648,7 +649,7 @@ namespace Xalia.Win32
             List<ElementIdentifier> children;
             try
             {
-                children = await Connection.CommandThread.OnBackgroundThread(() =>
+                children = await CommandThread.OnBackgroundThread(() =>
                 {
                     List<ElementIdentifier> result;
                     var count = 0;
@@ -676,7 +677,7 @@ namespace Xalia.Win32
                             break;
                     }
                     return result;
-                }, Tid);
+                }, CommandThreadPriority.Query);
             }
             catch (Exception e)
             {
@@ -897,10 +898,10 @@ namespace Xalia.Win32
             object role_obj;
             try
             {
-                role_obj = await Connection.CommandThread.OnBackgroundThread(() =>
+                role_obj = await CommandThread.OnBackgroundThread(() =>
                 {
                     return IAccessible.get_accRole(ChildId);
-                }, RootHwnd.Tid + 1);
+                }, CommandThreadPriority.Query);
             }
             catch (Exception e)
             {
@@ -957,10 +958,10 @@ namespace Xalia.Win32
         {
             try
             {
-                await Connection.CommandThread.OnBackgroundThread(() =>
+                await CommandThread.OnBackgroundThread(() =>
                 {
                     IAccessible.accDoDefaultAction(ChildId);
-                }, Tid);
+                }, CommandThreadPriority.User);
             }
             catch (Exception e)
             {

--- a/xalia/Win32/HwndComboBoxProvider.cs
+++ b/xalia/Win32/HwndComboBoxProvider.cs
@@ -23,6 +23,8 @@ namespace Xalia.Win32
         public UiDomElement Element => HwndProvider.Element;
         public int Tid => HwndProvider.Tid;
 
+        public CommandThread CommandThread => HwndProvider.CommandThread;
+
         public IntPtr HwndList { get; private set; }
         private bool _fetchingComboBoxInfo;
 
@@ -233,10 +235,10 @@ namespace Xalia.Win32
         private async Task FetchComboBoxInfo()
         {
             COMBOBOXINFO info;
-            info = await Connection.CommandThread.OnBackgroundThread(() =>
+            info = await CommandThread.OnBackgroundThread(() =>
             {
                 return FetchComboBoxInfoBackground();
-            }, Tid + 1);
+            }, CommandThreadPriority.Query);
             if (info.cbSize == 0)
                 // message failed
                 return;

--- a/xalia/Win32/NonclientProvider.cs
+++ b/xalia/Win32/NonclientProvider.cs
@@ -19,6 +19,7 @@ namespace Xalia.Win32
         public Win32Connection Connection => HwndProvider.Connection;
         public int Pid => HwndProvider.Pid;
         public int Tid => HwndProvider.Tid;
+        public CommandThread CommandThread => HwndProvider.CommandThread;
 
         public override UiDomValue EvaluateIdentifier(UiDomElement element, string identifier, HashSet<(UiDomElement, GudlExpression)> depends_on)
         {

--- a/xalia/Win32/NonclientScrollProvider.cs
+++ b/xalia/Win32/NonclientScrollProvider.cs
@@ -278,7 +278,7 @@ namespace Xalia.Win32
             SCROLLBARINFO sbi;
             try
             {
-                sbi = await Connection.CommandThread.OnBackgroundThread(() =>
+                sbi = await CommandThread.OnBackgroundThread(() =>
                 {
                     if (!AnySbiInfoCurrent(old_change_count))
                         return default;
@@ -287,7 +287,7 @@ namespace Xalia.Win32
                     if (!GetScrollBarInfo(Hwnd, Vertical ? OBJID_VSCROLL : OBJID_HSCROLL, ref _sbi))
                         throw new Win32Exception();
                     return _sbi;
-                }, Tid);
+                }, CommandThreadPriority.Query);
             }
             catch (Win32Exception e)
             {
@@ -360,7 +360,7 @@ namespace Xalia.Win32
             SCROLLINFO new_si;
             try
             {
-                new_si = await Connection.CommandThread.OnBackgroundThread(() =>
+                new_si = await CommandThread.OnBackgroundThread(() =>
                 {
                     if (old_change_count != _siChangeCount)
                         return default;
@@ -371,7 +371,7 @@ namespace Xalia.Win32
                         throw new Win32Exception();
 
                     return si;
-                }, Tid);
+                }, CommandThreadPriority.Query);
             }
             catch (Win32Exception e)
             {
@@ -416,7 +416,7 @@ namespace Xalia.Win32
         {
             try
             {
-                return await Connection.CommandThread.OnBackgroundThread(() =>
+                return await CommandThread.OnBackgroundThread(() =>
                 {
                     var sbi = new SCROLLBARINFO();
                     sbi.cbSize = Marshal.SizeOf<SCROLLBARINFO>();
@@ -430,7 +430,7 @@ namespace Xalia.Win32
                         throw new Win32Exception();
 
                     return CalculateMinimumIncrement(sbi, si);
-                }, Tid);
+                }, CommandThreadPriority.User);
             }
             catch (Win32Exception e)
             {
@@ -454,7 +454,7 @@ namespace Xalia.Win32
         {
             try
             {
-                SCROLLINFO si = await Connection.CommandThread.OnBackgroundThread(() =>
+                SCROLLINFO si = await CommandThread.OnBackgroundThread(() =>
                 {
                     var bg_si = new SCROLLINFO();
                     bg_si.cbSize = Marshal.SizeOf<SCROLLINFO>();
@@ -463,7 +463,7 @@ namespace Xalia.Win32
                         throw new Win32Exception();
 
                     return bg_si;
-                }, Tid);
+                }, CommandThreadPriority.User);
 
                 if (si.max_value <= si.nMin)
                     return false;


### PR DESCRIPTION
This works independent of COM marshaling, which is not implemented in Mono.