### PR TITLE
sdl: Create a hidden window to avoid polling.

### DIFF
--- a/xalia/Sdl/SdlSynchronizationContext.cs
+++ b/xalia/Sdl/SdlSynchronizationContext.cs
@@ -31,6 +31,11 @@ namespace Xalia.Sdl
 
         private uint _queue_updated_event;
 
+        // SDL_WaitEvent needs an SDL-owned window to use event driven poll loop.
+        // Without one, SDL falls back to polling with SDL_DelayNS every millisecond, which is especially expensive on
+        // Wine.
+        private IntPtr _event_window;
+
         private SdlSynchronizationContext()
         {
         }
@@ -50,6 +55,14 @@ namespace Xalia.Sdl
             if (!SDL_Init(flags))
             {
                 throw new ApplicationException(SDL_GetError());
+            }
+
+            _event_window = SDL_CreateWindow("Xalia event window", 1, 1, SDL_WindowFlags.SDL_WINDOW_HIDDEN);
+            if (_event_window == IntPtr.Zero)
+            {
+                string error = SDL_GetError();
+                SDL_Quit();
+                throw new ApplicationException(error);
             }
 
             _queue_updated_event = SDL_RegisterEvents(1);
@@ -74,6 +87,11 @@ namespace Xalia.Sdl
             if (DebugMainLoop)
                 Utils.DebugWriteLine($"MAINLOOP: Queued quit");
             _quitting = true;
+            if (_event_window != IntPtr.Zero)
+            {
+                SDL_DestroyWindow(_event_window);
+                _event_window = IntPtr.Zero;
+            }
             SDL_Quit();
         }
 


### PR DESCRIPTION
SDL_WaitEvents pumps the message loop if an "active" window is available [1], and otherwise falls back to a 1000Hz poll loop. The poll loop is problematic both because the frequency and its use of SetWaitableTimerEx which incurs server calls.

Creating a hidden window seems to make SDL pick the message loop path which is much more quiet.

Tested with a Unity game and the SetWaitableTimerEx calls are suppressed, while no visible X11 window nor focus stealing behavior was observed.

[1]: https://github.com/libsdl-org/SDL/blob/8319d69f7286f40b3cacdb2c8216c8a6dd6a239c/src/events/SDL_events.c#L1786